### PR TITLE
Node Alpine docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:10-alpine
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:10-alpine
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  frontend:
+    build:
+      context: .
+    ports:
+     - "8080:8080"


### PR DESCRIPTION
Node Alpine Docker image (about 36 MB) instead of regular node image (300+ MB).

Wanted to upgrade to v12, but as `node-sass` didn't have a prebuilt binary for that version and thus required Python to build one, I abandoned it.

Also made a rudimentary `docker-compose.yml` file for easy deployment.