### PR TITLE
Name max length check

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -29,6 +29,13 @@ const Constants = {
         '#039587',
         '#344562',
     ],
+    forms: {
+        maxLength: {
+            "FEATURE_ID" : 256,
+            "SEGMENT_ID" : 256,
+            "TRAITS_ID" : 256
+        },
+    },
     defaultRule: {
         property: '',
         operator: 'EQUAL',
@@ -159,7 +166,7 @@ const Constants = {
             'Node JS': require('./code-help/install/install-node')(keywords),
             'Java': require('./code-help/install/install-java')(keywords),
             '.NET': require('./code-help/install/install-dotnet')(keywords),
-        },
+        }, 
     },
     simulate: {},
     roles: {

--- a/common/constants.js
+++ b/common/constants.js
@@ -31,9 +31,9 @@ const Constants = {
     ],
     forms: {
         maxLength: {
-            "FEATURE_ID" : 256,
-            "SEGMENT_ID" : 256,
-            "TRAITS_ID" : 256
+            "FEATURE_ID" : 150,
+            "SEGMENT_ID" : 150,
+            "TRAITS_ID" : 150
         },
     },
     defaultRule: {

--- a/web/components/modals/CreateFlag.js
+++ b/web/components/modals/CreateFlag.js
@@ -7,6 +7,9 @@ import data from '../../../common/data/base/_data';
 import SegmentOverrides from '../SegmentOverrides';
 import AddEditTags from '../AddEditTags';
 import TagList from '../TagList';
+import Constants from '../../../common/constants';
+
+const FEATURE_ID_MAXLENGTH = Constants.forms.maxLength.FEATURE_ID;
 
 const CreateFlag = class extends Component {
     static displayName = 'CreateFlag'
@@ -114,7 +117,7 @@ const CreateFlag = class extends Component {
         const Provider = identity ? IdentityProvider : FeatureListProvider;
         const valueString = isEdit ? 'Value' : 'Initial value';
         const enabledString = isEdit ? 'Enabled' : 'Enabled by default';
-
+       
         return (
             <ProjectProvider
               id={this.props.projectId}
@@ -163,7 +166,6 @@ const CreateFlag = class extends Component {
                                         </Tabs>
                                     </FormGroup>
                                 )}
-
                                 <FormGroup className="mb-4 mr-3 ml-3">
                                     <InputGroup
                                       ref={e => this.input = e}
@@ -172,6 +174,7 @@ const CreateFlag = class extends Component {
                                           readOnly: isEdit,
                                           className: 'full-width',
                                           name: 'featureID',
+                                          maxLength: FEATURE_ID_MAXLENGTH,
                                       }}
                                       value={name}
                                       onChange={e => this.setState({ name: Format.enumeration.set(Utils.safeParseEventValue(e)).toLowerCase() })}

--- a/web/components/modals/CreateSegment.js
+++ b/web/components/modals/CreateSegment.js
@@ -3,6 +3,9 @@ import engine from 'bullet-train-rules-engine';
 import Rule from './Rule';
 import Highlight from '../Highlight';
 import SegmentStore from '../../../common/stores/segment-list-store';
+import Constants from '../../../common/constants';
+
+const SEGMENT_ID_MAXLENGTH = Constants.forms.maxLength.SEGMENT_ID;
 
 const CreateSegment = class extends Component {
     static displayName = 'CreateSegment'
@@ -167,7 +170,8 @@ const CreateSegment = class extends Component {
                               inputProps={{
                                   className: 'full-width',
                                   name: 'segmentID',
-                                  readOnly: isEdit
+                                  readOnly: isEdit,
+                                  maxLength: SEGMENT_ID_MAXLENGTH
                               }}
                               value={name}
                               onChange={e => this.setState({ name: Format.enumeration.set(Utils.safeParseEventValue(e)).toLowerCase() })}

--- a/web/components/modals/CreateTrait.js
+++ b/web/components/modals/CreateTrait.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import Highlight from '../Highlight';
+import Constants from '../../../common/constants';
+
+const TRAITS_ID_MAXLENGTH = Constants.forms.maxLength.TRAITS_ID;
 
 const CreateTrait = class extends Component {
     static displayName = 'CreateTrait'
@@ -62,6 +65,7 @@ const CreateTrait = class extends Component {
                                           readOnly: isEdit,
                                           className: 'full-width',
                                           name: 'traitID',
+                                          maxLength: TRAITS_ID_MAXLENGTH,
                                       }}
                                       value={trait_key}
                                       onChange={e => this.setState({ trait_key: Format.enumeration.set(Utils.safeParseEventValue(e)).toLowerCase() })}


### PR DESCRIPTION
Hi, 

I encountered that there was no limit for feature, segment and traits ID's as shown in the screenshot below. I have made these lengths configurable in "constant.js" file.

![image](https://user-images.githubusercontent.com/37799932/89101564-a1fc5f00-d41e-11ea-8226-3b211962afbb.png)

Kindly look into the changes and suggest if you require any other length for the ID's. 

Regards,
Sahana 