### PR TITLE
fix: sign-in screen flashed before showing requested page, during page reload - even for logged in users

### DIFF
--- a/common/providers/AccountProvider.js
+++ b/common/providers/AccountProvider.js
@@ -88,6 +88,18 @@ const AccountProvider = class extends Component {
 
     render() {
         const { isLoading, isSaving, user, organisation, organisations, error } = this.state;
+        if (isLoading) {
+            return (
+                <div style={{
+                    position: 'absolute',
+                    top: '35%',
+                    width: '100%',
+                    textAlign: 'center',
+                }}>
+                    <Loader />
+                </div>
+            );
+        }
         return (
             this.props.children({
                 isLoading,


### PR DESCRIPTION
**Before changes:**
When you reload the page, even if the user has alredy logged in the signin screen would flash before showing the requested page/screen. 

Screen recording of the same
https://app.box.com/s/5yjtxm7hb10mzhujrdqxaijav1gv6m7i


**After changes:**
When you reload the page, the signup screen is no longer shown if the user is already logged in. The flash screen is now replaced with a loader, while the API call is in progress.

Screen recording of the same
https://app.box.com/s/uzpntrwy3ksg9v6baizlfrdxsh1fyp1e


