### PR TITLE
Re add basename env var

### DIFF
--- a/bin/env.js
+++ b/bin/env.js
@@ -32,6 +32,7 @@ const values = [
     { name: 'flagsmithAnalytics', value: process.env.FLAGSMITH_ANALYTICS },
     { name: 'flagsmithClientAPI', value: process.env.FLAGSMITH_CLIENT_API },
     { name: 'amplitude', value: process.env.AMPLITUDE },
+    { name: 'basename', value: process.env.BASENAME },
 ];
 const output = values.map(getVariable).join('');
 const config = `window.projectOverrides = {

--- a/server/index.js
+++ b/server/index.js
@@ -61,6 +61,7 @@ app.get('/static/project-overrides.js', (req, res) => {
         { name: 'disableInflux', value: process.env.DISABLE_INFLUXDB_FEATURES },
         { name: 'flagsmithAnalytics', value: !!process.env.FLAGSMITH_ANALYTICS },
         { name: 'amplitude', value: process.env.AMPLITUDE },
+        { name: 'basename', value: process.env.BASENAME },
     ];
     const output = values.map(getVariable).join('');
 


### PR DESCRIPTION
It looks like there were some recent changes to where env vars were added to runtime and the recently added BASENAME was left out.